### PR TITLE
fix: use ruby/setup-ruby and separate deploy job in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,15 +33,26 @@ jobs:
         working-directory: map
 
       # Build Jekyll site
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
-      - run: bundle install
+          ruby-version: '3.3'
+          bundler-cache: true
+      - uses: actions/configure-pages@v5
       - run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
 
       # Merge: copy Astro output into Jekyll output
       - run: cp -r map/dist _site/map
 
-      # Deploy
       - uses: actions/upload-pages-artifact@v3
-      - uses: actions/deploy-pages@v4
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Replace deprecated `actions/setup-ruby@v1` with `ruby/setup-ruby@v1`
- Use Ruby 3.3 (matching `.ruby-version`) — 3.1 was not available
- Add `bundler-cache: true` (replaces manual `bundle install`, with gem caching)
- Add `actions/configure-pages@v5` and `JEKYLL_ENV=production`
- Split `deploy-pages` into separate job with `environment: github-pages` (matches GitHub's official starter workflow pattern)

## Test plan

- [ ] CI build job passes (Ruby installs, Jekyll builds, Astro builds)
- [ ] Deploy job succeeds (requires Pages source set to "GitHub Actions")