### PR TITLE
fix: exclude vendor/ from Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ exclude:
   - map
   - content
   - node_modules
+  - vendor
 
 # Social/SEO
 url: "https://iptf.ethereum.org"


### PR DESCRIPTION
## Summary

- Add `vendor` to `_config.yml` exclude list
- Custom `exclude` overrides Jekyll defaults (which normally exclude `vendor/`), causing Jekyll to choke on gem template files in `vendor/bundle/`

One-line fix. CI should pass with this — the `vendor/bundle/` error from the last run will be gone.

## Test plan

- [ ] CI build job passes (Jekyll no longer tries to process vendor/bundle/ files)