### PR TITLE
fix: add repository to config for jekyll-github-metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,7 @@ exclude:
 
 # Social/SEO
 url: "https://iptf.ethereum.org"
+repository: ethereum/iptf-web
 lang: en
 
 author:


### PR DESCRIPTION
## Summary

- Add `repository: ethereum/iptf-web` to `_config.yml`
- `jekyll-github-metadata` (bundled in `github-pages` gem) can't auto-detect the repo when deploying via Actions instead of built-in Pages

## Test plan

- [ ] CI build passes — Jekyll no longer errors on missing repo name